### PR TITLE
Avoid to use config.yml file or any redundant construct.

### DIFF
--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -2,15 +2,22 @@ import dash
 import yaml
 from flask import Flask
 import dash_bootstrap_components as dbc
+import os
 
+# TODO, begin: this should not exists.
 with open("config.yml") as f:
     config = yaml.safe_load(f)
+
+print(config)
+# TODO, end.
+
+dashboard_id = os.path.basename(os.getcwd())
 
 application = Flask("example_dashboard")
 app = dash.Dash(name=__name__,
                 server=application,
                 suppress_callback_exceptions=True,
                 external_stylesheets=[dbc.themes.FLATLY],
-                url_base_pathname=f'/{config["dashboard_id"]}/')
+                url_base_pathname=f'/{dashboard_id}/')
 
 server = app.server

--- a/dashboard/apps/page_1.py
+++ b/dashboard/apps/page_1.py
@@ -6,11 +6,12 @@ import dash_bootstrap_components as dbc
 import pylana
 import lana_listener
 import json
+import os
 
-from app import app, config
+from urllib.parse import urlparse
 from navbar import navbar
 from graph_objects import indicator_div, indicator_col
-
+from app import app
 
 ll = lana_listener.LanaListener(
     id='LanaListener',
@@ -49,13 +50,13 @@ layout = html.Div(children=[ll,
      Input('LanaListener', 'lana_trace_filter_sequence')]
 )
 def update_indicator_median_tfs(api_key, log_id, tfs):
+    fooConfig = urlparse(os.environ['JANUS_URL'])
     api_key = api_key[8:]
     tfs = json.loads(tfs)
-
     api = pylana.create_api(**{
-        "scheme": config["scheme"],
-        "host": config["host"],
-        "port": config["port"],
+        "scheme": fooConfig.scheme,
+        "host": fooConfig.hostname,
+        "port": fooConfig.port,
         "token": api_key
     })
 
@@ -74,12 +75,12 @@ def update_indicator_median_tfs(api_key, log_id, tfs):
      Input('LanaListener', 'lana_log_id')]
 )
 def number_cases(api_key, log_id):
+    fooConfig = urlparse(os.environ['JANUS_URL'])
     api_key = api_key[8:]
-
     api = pylana.create_api(**{
-        "scheme": config["scheme"],
-        "host": config["host"],
-        "port": config["port"],
+        "scheme": fooConfig.scheme,
+        "host": fooConfig.hostname,
+        "port": fooConfig.port,
         "token": api_key
     })
 
@@ -97,13 +98,14 @@ def number_cases(api_key, log_id):
      Input('LanaListener', 'lana_trace_filter_sequence')]
 )
 def number_case_tfs(api_key, log_id, tfs):
+    fooConfig = urlparse(os.environ['JANUS_URL'])
     api_key = api_key[8:]
     tfs = json.loads(tfs)
 
     api = pylana.create_api(**{
-        "scheme": config["scheme"],
-        "host": config["host"],
-        "port": config["port"],
+        "scheme": fooConfig.scheme,
+        "host": fooConfig.hostname,
+        "port": fooConfig.port,
         "token": api_key
     })
 

--- a/dashboard/index.py
+++ b/dashboard/index.py
@@ -2,6 +2,9 @@ from dash.dependencies import Input, Output
 import dash_core_components as dcc
 import dash_html_components as html
 
+import os
+
+
 from app import app, application, config
 from apps import page_1, page_2
 
@@ -14,8 +17,7 @@ app.layout = html.Div([
     html.Div(id='page-content')
 ])
 
-dashboard_id = config["dashboard_id"]
-
+dashboard_id = os.path.basename(os.getcwd())
 
 @app.callback(Output('page-content', 'children'),
               [Input('url', 'pathname')])


### PR DESCRIPTION
Please take this pull-request with a pinch of salt!

It is not necessarily for an actual merge into the _main_ branch, but rather to show what shall be changed in order to eliminate _config.yml_. - yet, a merge may be an option if the changes are appropriate to how the python statements have been formulated.

The existence of `JANUS_URL` environment variable is assumed by any dashboard source code, indeed that is a requirement.
- The lack of definition of `JANUS_URL` shall be tackled,
- use of _config.yml_ completely eliminated,

It is also strongly recommended to not use hardcoded IDs in any externally handled code.

The back-end will not be able to execute code that does not comply with the expected schema.